### PR TITLE
For python3 pip installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ You should be able to install using `easy_install` or `pip` in the usual ways:
 $ easy_install random-word
 $ pip install random-word
 ```
-
+>>>>for python3 use <pre> $ pip3 install random-word</pre>
 Or just clone this repository and run:
 
 ```sh

--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ $ easy_install random-word
 $ pip install random-word
 ```
 >>>>for python3 use <pre> $ pip3 install random-word</pre>
+
+
+
+
 Or just clone this repository and run:
 
 ```sh


### PR DESCRIPTION
if we use "pip install random-word" them it cretes an error rather than we should use latest version for python3 i.e "pip3 install random-word"