### PR TITLE
Updated README and added an optional argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,16 @@ r.get_random_words()
 r.word_of_the_day()
 ```
 
-## Advance Usage
+## Advanced Usage
 
-1.  To generate single random word we can use these optional parameters
+1.  To use a personal API key, we can pass the optional parameter api_key when creating the RandomWords object
+
+    ```python
+    r = RandomWords(api_key="YOUR_PERSONAL_API_KEY_HERE")
+
+    ```
+
+2.  To generate single random word we can use these optional parameters
 
     - `hasDictionaryDef (string)` - Only return words with dictionary definitions (optional)
     - `includePartOfSpeech (string)` - CSV part-of-speech values to include (optional)
@@ -57,6 +64,7 @@ r.word_of_the_day()
     - `maxDictionaryCount (integer)` - Maximum dictionary count (optional)
     - `minLength (integer)` - Minimum word length (optional)
     - `maxLength (integer)` - Maximum word length (optional)
+    - `length (integer)` - Exact word length (optional)
 
     ```python
     r.get_random_word(hasDictionaryDef="true", includePartOfSpeech="noun,verb", minCorpusCount=1, maxCorpusCount=10, minDictionaryCount=1, maxDictionaryCount=10, minLength=5, maxLength=10)
@@ -64,7 +72,7 @@ r.word_of_the_day()
     # Output: pediophobia
     ```
 
-2.  To generate list of random word we can use these optional parameters
+3.  To generate list of random word we can use these optional parameters
 
     - `hasDictionaryDef (string)` - Only return words with dictionary definitions (optional)
     - `includePartOfSpeech (string)` - CSV part-of-speech values to include (optional)
@@ -75,6 +83,7 @@ r.word_of_the_day()
     - `maxDictionaryCount (integer)` - Maximum dictionary count (optional)
     - `minLength (integer)` - Minimum word length (optional)
     - `maxLength (integer)` - Maximum word length (optional)
+    - `length (integer)` - Exact word length (optional)
     - `sortBy (string)` - Attribute to sort by `alpha` or `count` (optional)
     - `sortOrder (string)` - Sort direction by `asc` or `desc` (optional)
     - `limit (integer)` - Maximum number of results to return (optional)
@@ -85,7 +94,7 @@ r.word_of_the_day()
     # Output: ['ambivert', 'calcspar', 'deaness', 'entrete', 'gades', 'monkeydom', 'outclimbed', 'outdared', 'pistoleers', 'redbugs', 'snake-line', 'subrules', 'subtrends', 'torenia', 'unhides']
     ```
 
-3.  To get word of the day we can use these optional parameters
+4.  To get word of the day we can use these optional parameters
 
     - `date (string)` - Fetches by date in yyyy-MM-dd (optional)
 

--- a/random_word/random_word.py
+++ b/random_word/random_word.py
@@ -47,9 +47,16 @@ class RandomWords(object):
             maxDictionaryCount, int: Maximum dictionary count (optional)
             minLength, int: Minimum word length (optional)
             maxLength, int: Maximum word length (optional)
-
+            length, int: Exact word length (optional)
         Returns: String, Random words
         """
+        params = locals()
+        try:
+            if params["kwargs"]["length"]:
+                params["kwargs"]["minLength"] = params["kwargs"]["maxLength"] = params["kwargs"]["length"]
+                del params["kwargs"]["length"]
+        except:
+            pass
 
         url = "https://api.wordnik.com/v4/words.json/randomWord?"
         allParams = [
@@ -61,9 +68,9 @@ class RandomWords(object):
             "minDictionaryCount",
             "maxDictionaryCount",
             "minLength",
-            "maxLength",
+            "maxLength"
         ]
-        params = locals()
+
         payload = params["kwargs"]
         check_payload_items(payload, allParams)
         payload["api_key"] = self.__api_key
@@ -102,12 +109,20 @@ class RandomWords(object):
             maxDictionaryCount, int: Maximum dictionary count (optional)
             minLength, int: Minimum word length (optional)
             maxLength, int: Maximum word length (optional)
+            length, int: Exact word length (optional)
             sortBy, str: Attribute to sort by (optional)
             sortOrder, str: Sort direction (optional)
             limit, int: Maximum number of results to return (optional)
 
         Returns: list[Random Words]
         """
+        params = locals()
+        try:
+            if params["kwargs"]["length"]:
+                params["kwargs"]["minLength"] = params["kwargs"]["maxLength"] = params["kwargs"]["length"]
+                del params["kwargs"]["length"]
+        except:
+            pass
 
         url = "https://api.wordnik.com/v4/words.json/randomWords?"
         allParams = [
@@ -124,7 +139,7 @@ class RandomWords(object):
             "sortOrder",
             "limit",
         ]
-        params = locals()
+
         payload = params["kwargs"]
         check_payload_items(payload, allParams)
         payload["api_key"] = self.__api_key


### PR DESCRIPTION
I have updated the README.md file for v1.0.5, which mentions that the user can also use their personal API keys. Also, added an optional parameter 'length' in the get_random_word() and get_random_words() functions which reduces the function call's verbosity when a word of an certain length is required.

This solves three issues in total #49 #35 #22 