### PR TITLE
Fixing a typo error in the main code

### DIFF
--- a/random_word/random_word.py
+++ b/random_word/random_word.py
@@ -191,7 +191,7 @@ class RandomWords(object):
         if response.status_code == 200:
             word = result["word"]
             definitions = result["definitions"]
-            return json.dumps({"word": word, "definations": definitions})
+            return json.dumps({"word": word, "definitions": definitions})
         else:
             if len(API_KEYS_LIST) == 0:
                 raise Exception(


### PR DESCRIPTION
There was a typo in the word definition (it was spelled defination) so I fixed that. That's it.